### PR TITLE
Use get_stylesheet_directory() for override folders in child theme

### DIFF
--- a/typerocket-v6.php
+++ b/typerocket-v6.php
@@ -85,7 +85,7 @@ final class OpenPlugin6
         if( defined('TYPEROCKET_OVERRIDE_PATH') ) {
             $temp_dir = TYPEROCKET_OVERRIDE_PATH;
         } else {
-            $temp_dir = get_template_directory();
+            $temp_dir = get_stylesheet_directory();
         }
 
         // maybe get config from theme


### PR DESCRIPTION
# Issue

When a child theme is active, the TypeRocket plugin will currently check the parent theme for override folders. This is because the function `get_template_directory()` will find the parent of a child theme if a child theme is active.

Source: [`get_template_directory()` function][get_template_directory]

> In the case a child theme is being used, the absolute path to the parent theme directory will be returned. Use [get_stylesheet_directory()](https://developer.wordpress.org/reference/functions/get_stylesheet_directory/) to get the absolute path to the child theme directory.

## Solution

Use the function `get_stylesheet_directory()` instead as recommended by the above docs.

[get_template_directory]: https://developer.wordpress.org/reference/functions/get_template_directory/